### PR TITLE
Use datatracker.ietf.org URL for RFC 6839

### DIFF
--- a/index.html
+++ b/index.html
@@ -968,7 +968,7 @@
             <dt>Optional parameters:</dt>
             <dd>"N/A"</dd>
             <dt>Encoding considerations:</dt>
-            <dd>MiniApp packages are binary files encoded in the <a href="https://www.iana.org/assignments/media-types/application/zip">application/zip</a> media type. See <a href="https://tools.ietf.org/html/rfc6839#section-3.6">RFC 6839, section 3.6</a> [[RFC6839]].</dd>
+            <dd>MiniApp packages are binary files encoded in the <a href="https://www.iana.org/assignments/media-types/application/zip">application/zip</a> media type. See <a href="https://datatracker.ietf.org/doc/html/rfc6839#section-3.6">RFC 6839, section 3.6</a> [[RFC6839]].</dd>
             <dt>Security considerations:</dt>
             <dd>Security considerations that apply to application/zip also apply to MiniApp package files. User agents that process MiniApp package files should rigorously check the size and validity of data retrieved. When digital signatures are available in a MiniApp package file, the user agent SHOULD implement necessary mechanisms to check the integrity and trustworthiness of the file according to the digital signatures, so as to to protect the end user and the hosting platform from the damage of package tampering or corruption. See more at [[[#sec-security-privacy]]].</dd>
             <dt>Interoperability considerations:</dt>


### PR DESCRIPTION
tools.ietf.org is no longer to be relied on per https://mailarchive.ietf.org/arch/msg/tools-discuss/oYrAxb3KayPzZ4SNB1DVZTDPPNo/


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/miniapp-packaging/pull/37.html" title="Last updated on Oct 8, 2021, 6:12 AM UTC (08188f3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/miniapp-packaging/37/2148d17...08188f3.html" title="Last updated on Oct 8, 2021, 6:12 AM UTC (08188f3)">Diff</a>