### PR TITLE
Fix ReSpec warning (processing algorithm not linked from anywhere)

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
         <h2>Introduction</h2>
         <section>
             <h3>Overview</h3>
-            <p>[=MiniApp=] is a concept of light software application, that can be distributed through any digital means, and accessed through the Web. MiniApps are defined by a concrete file structure and all their resources are packed within a single file that represents the whole [=MiniApp package=] that can be processed and executed by [=MiniApp user agents=].</p>
+            <p>[=MiniApp=] is a concept of light software application, that can be distributed through any digital means, and accessed through the Web. MiniApps are defined by a concrete file structure and all their resources are packed within a single file that represents the whole [=MiniApp package=] that can <a href="#dfn-process-a-miniapp-package" data-link-type="dfn">be processed</a> and executed by [=MiniApp user agents=].</p>
             <p>A [=MiniApp package=] contains a directory structure that holds the specific resources of the MiniApp that defines the rendering, operation, and interaction with the end-users — including static page templates, stylesheets, JavaScript documents, media files, and other resources — and the manifest. The <a href="https://www.w3.org/TR/miniapp-manifest/#dfn-miniapp-manifest-s" data-link-type="dfn">MiniApp manifest</a>, located in the central directory of the package, describes the MiniApp, including information about page routing, styles, and other operational and rendering details of the MiniApp, as well as descriptive information for humans.</p>
             <p>As defined in <a href="#sec-security-privacy">Security and Privacy Considerations</a>, MiniApps MAY support [=digital signature=] verification to guarantee the integrity of the package and contents during the delivery of the package.</p>
             <p>The MiniApp runtime environment ([=MiniApp user agent=]) identifies MiniApp package files through the standard [=MiniApp package=] format and the specific MIME media type, defined in this document. After retrieving the [=MiniApp ZIP container=], the [=MiniApp user agent=] loads the static page templates, stylesheets, JavaScript files, and other resources into the cache, following a <a href="#sec-miniapp-processing">dereference and processing algorithm</a>. These [=MiniApp resources=] will remain available in the cache until the next update, avoiding unnecessary network fetches.</p>
@@ -477,7 +477,7 @@
         <p>
             [=User agents=] MUST follow the following algorithm to dereference, parse and execute a [=MiniApp package=]. 
         </p>
-        <p>To <dfn>process a MiniApp package</dfn>, given [=URL=] |miniapp_uri:URL|, perform the following steps:</p>
+        <p>To <dfn data-export="">process a MiniApp package</dfn>, given [=URL=] |miniapp_uri:URL|, perform the following steps:</p>
         <ol class="algorithm">
             <li>Let |miniapp_zip_file:MiniApp ZIP container| be the result of [=retrieving a MiniApp ZIP container=] with |miniapp_uri|.</li>
             <li>[=Verify a MiniApp ZIP container=] with |miniapp_zip_file|.</li>

--- a/index.html
+++ b/index.html
@@ -585,7 +585,7 @@
             </section>
             <section id="sec-miniapp-platform-start-page-identification">
                 <h4>Start Page Identification</h4>
-                <p>By default, [=user agents=] MUST load the [=start page=] indicated in the <a href="https://www.w3.org/TR/miniapp-manifest/#dfn-miniapp-manifest-s" data-link-type="dfn">MiniApp manifest</a> as the entry point when the MiniApp <a href="sec-miniapp-processing-execute">is launched</a>. This [=start page=] by default MUST be overridden if a valid [=page=] is specified in the MiniApp URI, as specified in the following algorithm.</p>
+                <p>By default, [=user agents=] MUST load the [=start page=] indicated in the <a href="https://www.w3.org/TR/miniapp-manifest/#dfn-miniapp-manifest-s" data-link-type="dfn">MiniApp manifest</a> as the entry point when the MiniApp is launched. This [=start page=] by default MUST be overridden if a valid [=page=] is specified in the MiniApp URI, as specified in the following algorithm.</p>
                 <p >To <dfn data-lt="determining the start page">determine the start page</dfn>, given [=MiniApp Package=] |miniapp_package:MiniApp Package|, [=URL=] |miniapp_uri:URL|, and [=ordered map=] |manifest:ordered map|, perform the following steps. They return a [=URL=].</p>
                 <ol class="algorithm">
                     <li>Let |start_page:URL| be the result of [=extracting the start page from URI=], passing |miniapp_uri|.</li>

--- a/index.html
+++ b/index.html
@@ -626,7 +626,21 @@
                 </ol>
             </section>                
         </section>
-    </section>         
+    </section>
+    
+    <section id="sec-accessibility" class="informative">
+        <h2>Accessibility Considerations</h2>
+        <p>
+            This specification defines a MiniApp in logical and physical terms, detailing its <a href="#sec-conformance">internal file structure</a> and how the different <a href="#sec-miniapp-resources">resources</a> are packed within <a href="#sec-miniapp-zip-container">a single file</a>. Also, the document includes algorithms for the MiniApp user agents to <a href="#sec-miniapp-processing">retrieve and process</a> a MiniApp container.
+        </p>
+        <p>
+            The MiniApp Packaging specification requires user agents to process the MiniApp container and its content to generate a user interface and a concrete behavior based on the <a href="#sec-filestructure">internal resources</a> (i.e., HTML, stylesheets, scripting, and others) and the configuration (i.e., manifest, app.ux). User agents must ensure that the user interface and rendered content after the package processing and load are perceivable and operable under all circumstances and in every potential scenario. User agents must enable the configuration of different stylesheets to adapt the appearance to the user’s requirements, also offer the possibility to configure and control the display and the orientation of windows and viewports, as required by some members of the `manifest.json` ([[[MINIAPP-MANIFEST]]]).
+        </p>
+        <p>
+            Although not specified in this document, it is recommended that user agents guarantee the accessibility aspects in the user interaction, like offering full keyboard access or support alternative input devices (if feasible) and enabling users to store the preference settings to facilitate interaction. MiniApp user agents and platforms should provide mechanisms for rendering and interacting with the application, facilitating the integration of assistive technology, and complying with applicable specifications and conventions, particularly the [[[UAAG20]]].
+        </p>
+    </section>   
+
     <section id="sec-security-privacy">
         <h2>Security and Privacy Considerations</h2>
         <section>
@@ -646,7 +660,7 @@
             <h3>Content Confidentiality</h3>
             <p>This specification does not recommend any encryption mechanism for the [=MiniApp package=] to protect its confidentiality. However, it doesn't preclude an implementation from deploying some encryption mechanism for special purposes.</p>
         </section>
-    </section>    
+    </section> 
 
     <section class="appendix informative" id="sec-acknowledgments">
         <h2>Acknowledgments</h2>


### PR DESCRIPTION
Updated the markup of the document. Added a directive to export the definition of the entry point of the processing algorithm.  Also linked from the introduction to avoid the ReSpec warning.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/espinr/miniapp-packaging/pull/45.html" title="Last updated on Jan 25, 2022, 3:23 PM UTC (080466e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/miniapp-packaging/45/b50a97e...espinr:080466e.html" title="Last updated on Jan 25, 2022, 3:23 PM UTC (080466e)">Diff</a>