### PR TITLE
Respec defer instead of async

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <title>MiniApp Packaging</title>
-    <script async class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
+    <script defer class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
     <link rel="stylesheet" href="local.css">
     <script class="remove">
         var respecConfig = {


### PR DESCRIPTION
Respec script in `defer` mode instead of `async`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/espinr/miniapp-packaging/pull/67.html" title="Last updated on Jan 26, 2023, 9:59 AM UTC (281a7cf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/miniapp-packaging/67/e9cdc2b...espinr:281a7cf.html" title="Last updated on Jan 26, 2023, 9:59 AM UTC (281a7cf)">Diff</a>