### PR TITLE
Dark scheme mode 

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <title>MiniApp Packaging</title>
+    <meta name="color-scheme"content="light dark”/>
     <script defer class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
     <link rel="stylesheet" href="local.css">
     <script class="remove">

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <title>MiniApp Packaging</title>
-    <meta name="color-scheme"content="light dark"/>
+    <meta name="color-scheme" content="light dark"/>
     <script defer class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
     <link rel="stylesheet" href="local.css">
     <script class="remove">

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <title>MiniApp Packaging</title>
-    <meta name="color-scheme"content="light dark”/>
+    <meta name="color-scheme"content="light dark"/>
     <script defer class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
     <link rel="stylesheet" href="local.css">
     <script class="remove">


### PR DESCRIPTION
Added `meta` for color-scheme.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/espinr/miniapp-packaging/pull/70.html" title="Last updated on Nov 13, 2024, 4:16 PM UTC (bbf6fc5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/miniapp-packaging/70/72e3fd1...espinr:bbf6fc5.html" title="Last updated on Nov 13, 2024, 4:16 PM UTC (bbf6fc5)">Diff</a>